### PR TITLE
Introduce `DecodeSessionError`.

### DIFF
--- a/src/internal/session/mod.rs
+++ b/src/internal/session/mod.rs
@@ -10,7 +10,7 @@ use internal::keys;
 use internal::keys::{IdentityKey, IdentityKeyPair, PreKeyBundle, PreKey, PreKeyId};
 use internal::keys::{KeyPair, PublicKey};
 use internal::message::{Counter, PreKeyMessage, Envelope, Message, CipherMessage};
-use internal::util::{self, DecodeError};
+use internal::util;
 use std::cmp::{Ord, Ordering};
 use std::collections::VecDeque;
 use std::error::{Error, FromError};
@@ -280,10 +280,10 @@ impl<'r> Session<'r> {
         util::encode(self, binary::enc_session).unwrap()
     }
 
-    pub fn decode(ident: &'r IdentityKeyPair, b: &[u8]) -> Result<Session<'r>, DecodeError> {
+    pub fn decode(ident: &'r IdentityKeyPair, b: &[u8]) -> Result<Session<'r>, binary::DecodeSessionError> {
         let mut b = b;
         let mut d = DecoderReader::new(&mut b, SizeLimit::Infinite);
-        binary::dec_session(ident, &mut d).map_err(FromError::from_error)
+        binary::dec_session(ident, &mut d)
     }
 
     pub fn local_identity(&self) -> &IdentityKey {

--- a/src/internal/util.rs
+++ b/src/internal/util.rs
@@ -13,15 +13,9 @@ use std::vec::Vec;
 
 // DecodeError //////////////////////////////////////////////////////////////
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DecodeError {
     cause: DecodingError
-}
-
-impl fmt::Debug for DecodeError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(f, "DecodeError: {:?}", self.cause)
-    }
 }
 
 impl fmt::Display for DecodeError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,3 +22,4 @@ pub fn init() {
 }
 
 pub use internal::util::DecodeError;
+pub use internal::session::binary::DecodeSessionError;


### PR DESCRIPTION
In case decoding fails due to a mismatch between the serialised identity key and the provided one, it is better to distinguish this error from other decoding errors. Client code can handle this case more easily.