### PR TITLE
Optionally sign prekeys.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license      = "MPL-2.0"
 byteorder   = ">  0.2.0"
 cbor-codec  = ">= 0.1.0"
 libc        = ">  0.1.0"
-sodiumoxide = ">  0.0.5"
+sodiumoxide = ">= 0.0.8"
 
 [dependencies.hkdf]
 git = "https://github.com/twittner/hkdf"

--- a/src/internal/message.rs
+++ b/src/internal/message.rs
@@ -96,7 +96,7 @@ impl Message {
         match try!(d.u8()) {
             1 => CipherMessage::decode(d).map(Message::Plain),
             2 => PreKeyMessage::decode(d).map(Message::Keyed),
-            t => Err(DecodeError::InvalidMessage(format!("unknown message type {}", t)))
+            t => Err(DecodeError::InvalidType(t, "unknown message type"))
         }
     }
 }


### PR DESCRIPTION
This PR suggests to sign the ephemeral public key in prekey bundles with the private identity key. Conversely, when initiating a session from a prekey bundle, verify the signature.

While this weakens deniability in one direction (see [this blog post](https://whispersystems.org/blog/simplifying-otr-deniability/)), ensuring that the ephemeral keys in prekey bundles are authentic prevents abuse scenarios with forged prekey bundles where the ephemeral key is exchanged with the goal of recording ciphertext that can later be decrypted once the long-term private key is compromised.

Especially in multi-device scenarios with mechanisms for extending trust from one device to another and thus from one identity key to another (e.g. through cloning or (cross-)signing of identity keys) it is otherwise possible for a malicious device or server to forge prekey bundles with their own ephemeral key pair and another device's identity. The goal thereby is to make the victim's device trust the malicious device through the existing trust on an identity key.
If successful, the malicious device will thus receive (and can record) all the ciphertext sent by the compromised client in conversations that the malicious device participates in. If it now ever manages to compromise the long-term private key that corresponds to the public key used in the attack, it can initialise its session and decrypt all of the recorded ciphertext.

This problem does not affect prekey messages, because here the attacker has to initialise his session first, so even though he can try to send a forged prekey message with someone else's public identity key, the recipient will not be able to decrypt it (triple-DH will yield a different secret) and thus fail to initialise the session.