### PR TITLE
Derive Clone for IdentityKeyPair

### DIFF
--- a/src/internal/keys.rs
+++ b/src/internal/keys.rs
@@ -53,6 +53,7 @@ impl IdentityKey {
 
 // Identity Keypair /////////////////////////////////////////////////////////
 
+#[derive(Clone)]
 pub struct IdentityKeyPair {
     pub version:    u8,
     pub secret_key: SecretKey,


### PR DESCRIPTION
It is effectively already possible to clone an `IdentityKeyPair` since all the components derive `Clone` and the fields are `pub`lic, so this just makes it nicer / easier syntax-wise.